### PR TITLE
Makefile changes for Darwin (Mac OS X)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,12 @@ LDFLAGS=-lImlib2
 PROG=icat
 MODS=icat.o
 
+uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo unknown')
+
+ifeq ($(uname_S),Darwin)
+	CCFLAGS:=$(CCFLAGS) -I/opt/X11/include
+endif
+
 all: $(PROG)
 
 %.o: %.c

--- a/README.md
+++ b/README.md
@@ -7,7 +7,12 @@ Building
 --------
 
 Build requirements: icat depends on imlib2.
-On Ubuntu, apt-get install libimlib2-dev.
+
+On Ubuntu, `apt-get install libimlib2-dev`
+
+On Darwin (Mac OS X), `brew install imlib2`
+
+Note that for Darwin (Mac OS X), you will need to install [XQuartz](http://xquartz.macosforge.org/landing/) first, the version of the X.Org X Window System (X11) that runs on OS X.
 
 To compile:
 


### PR DESCRIPTION
Hey @atextor

The title of the pull request sums it up nicely: some Darwin-only changes to the Makefile to ensure that `icat` compiles out-of-the-box on Mac OS X.

I've also included some documentation updates for Darwin.

Thanks for your consideration,

@pvdb
