### PR TITLE
Add a --width option

### DIFF
--- a/icat.c
+++ b/icat.c
@@ -107,6 +107,9 @@ void print_usage() {
 			"	-x value     -- Specify the column to print the image in (min. 1)\n"
 			"	-y value     -- Specify the row to print the image in (min. 1)\n"
 			"	                This is ignored when more than one image is printed.\n"
+			"       -w | --width <columns>\n"
+			"                       Instead of resizing the image to fit the terminal width,\n"
+			"                       use the provided value as the desired width.\n"
 			"	-k | --keep  -- Keep image size, i.e. do not automatically resize image to fit\n"
 			"	                the terminal width.\n"
 			"	-m | --mode indexed|24bit|both\n"
@@ -188,6 +191,7 @@ int main(int argc, char* argv[]) {
 	Imlib_Image image = NULL;
 	unsigned int x = 0;
 	unsigned int y = 0;
+	unsigned int user_w = 0;
 	int c;
 	bool keep_size = false;
 	int mode = MODE_INDEXED;
@@ -197,12 +201,13 @@ int main(int argc, char* argv[]) {
 			{"help", no_argument,       &display_help, 1},
 			{"x",    required_argument, 0, 'x'},
 			{"y",    required_argument, 0, 'y'},
+			{"width",required_argument, 0, 'w'},
 			{"keep", no_argument,       0, 'k'},
 			{"mode", required_argument, 0, 'm'},
 			{0, 0, 0, 0}
 		};
 
-		c = getopt_long(argc, argv, "hx:y:km:", long_options, NULL);
+		c = getopt_long(argc, argv, "hx:y:w:km:", long_options, NULL);
 
 		if (c == -1)
 			break;
@@ -219,6 +224,14 @@ int main(int argc, char* argv[]) {
 				y = atoi(optarg);
 				if (y < 0) {
 					y = 0;
+				}
+				break;
+
+			case 'w':
+				user_w = atoi(optarg);
+				if(user_w < 1) {
+					printf("Image width must be larger than 0\n");
+					exit(1);
 				}
 				break;
 
@@ -296,8 +309,8 @@ int main(int argc, char* argv[]) {
 		// Find out terminal size and resize image to fit, if necessary
 		if (!keep_size) {
 			int cols = terminal_width();
-			if (cols < width - 1) {
-				int resized_width = cols - 1;
+			if (cols < width - 1 || user_w) {
+				int resized_width = user_w ? user_w : cols - 1;
 				int resized_height = (int)(height * ((float)resized_width / width)); 
 				Imlib_Image resized_image = imlib_create_cropped_scaled_image(0, 0,
 						width, height, resized_width, resized_height);

--- a/icat.c
+++ b/icat.c
@@ -144,7 +144,7 @@ void resize_image_if_necessary(int *width, int *height, const int user_width) {
 	int resized_width;
 
 	if(!user_width) {
-		int cols = terminal_width() - 1;
+		int cols = terminal_width();
 		if(cols > *width) return;
 
 		resized_width = cols;

--- a/icat.man
+++ b/icat.man
@@ -1,4 +1,4 @@
-.TH ICAT 1 2017-10-20
+.TH ICAT 1 2018-03-27 "" "User Commands"
 .SH NAME
 icat - display images in terminal
 .SH SYNOPSIS
@@ -11,20 +11,25 @@ You can specify multiple images to be displayed.
 If you use "\fB-\fR" as the filename, the image will be read from standard input.
 .SH OPTIONS
 .TP
-\fB\-h\fR \fB\-\-help\fR
+\fB\-h\fR, \fB\-\-help\fR
 Display a help screen and exit.
 .TP
-\fB\-k\fR \fB\-\-keep\fR
+\fB\-k\fR, \fB\-\-keep\fR
 Do not automatically resize larger images to fit in terminal width.
+Using this overrides the \fB--width\fR option.
 .TP
-\fB\-m\fR \fB\-\-mode\fR <\fIindexed\fR, \fI24bit\fR, \fIboth\fR>
+\fB\-m\fR, \fB\-\-mode\fR <\fIindexed\fR, \fI24bit\fR, \fIboth\fR>
 Use indexed mode (256-color, the default), 24-bit color, or both.
 .TP
-\fB\-x\fR \fICOLUMNS\fR
+\fB\-w\fR, \fB\-\-width\fR \fICOLUMNS\fR
 Specifies how many terminal columns to use (controls width of output).
 .TP
-\fB\-y\fR \fIROWS\fR
-Specifies how many terminal rows to use (controls height of output).
+\fB\-x\fR \fICOLUMN\fR
+Specifies the column to output the image at (indexed starting from 1).
+.TP
+\fB\-y\fR \fIROW\fR
+Specifies the row to output the image at (indexed starting from 1).
+Ignored if more than one file is provided.
 .SH LICENCE
 This program is made available under the terms of the BSD (2-clause) licence.
 .SH AUTHOR


### PR DESCRIPTION
This changeset adds a `--width` option, allowing the user to explicitly specify the desired output width. It also fixes the _completely wrong_ information about the `-x` and `-y` options found in the man page.

I've also changed the automatic feature so images are allowed to reach full terminal width, instead of `width - 1`. I've tested this on a terminal emulator and a Linux tty and the images render fine.

May I suggest bumping the version to `0.5`, if this feature gets merged?